### PR TITLE
remove dependency twbs:bootstrap

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/bootstrap-tagsinput"]
 	path = lib/bootstrap-tagsinput
-	url = https://github.com/TimSchlechter/bootstrap-tagsinput.git
+	url = https://github.com/bootstrap-tagsinput/bootstrap-tagsinput

--- a/package.js
+++ b/package.js
@@ -8,7 +8,6 @@ Package.describe({
 Package.on_use(function (api) {
     // dependecies required by package
     api.use('jquery@1.0.1', 'client');
-    api.use('twbs:bootstrap@3.3.5','client')
     // adding the required file for package
     api.add_files('lib/bootstrap-tagsinput/dist/bootstrap-tagsinput.min.js', 'client');
     api.add_files('lib/bootstrap-tagsinput/dist/bootstrap-tagsinput.css', 'client');


### PR DESCRIPTION
I vote to abandon the bootstrap dependency. I for example use drskullster:bootstrap a configurable bootstrap package and having bootstrap added twice is not an option and hard to work around if a package depends on it, on the other hand it's really easy for people who don't have bootstrap already to do `meteor add twbs:bootstrap`
